### PR TITLE
Copy latest queries from tree-sitter-nu

### DIFF
--- a/queries/nu/injections.scm
+++ b/queries/nu/injections.scm
@@ -1,0 +1,1 @@
+(comment) @comment

--- a/queries/nu/locals.scm
+++ b/queries/nu/locals.scm
@@ -1,22 +1,13 @@
 ; Scopes
-
-(function_definition @scope)
-(block @scope)
-(record_or_block @scope)
+(function_definition) @scope
 
 ; Definitions
-(variable_declaration name: (identifier) @definition.var)
-(parameter (identifier) @definition.var)
-(flag (flag_name) @definition.var)
-(flag (flag_shorthand_name) @definition.var)
-(record_entry entry_name: (identifier) @definition.var)
-(block_args block_param: (identifier) @definition.var)
+(variable_declaration 
+  name: (identifier) @definition.var)
 
 (function_definition
   func_name: (identifier) @definition.function)
 
-
 ; References
-[
-    (value_path)
-] @reference
+(value_path) @reference
+(word) @reference


### PR DESCRIPTION
This MR fixes the following error which I get with the latest version of nvim-nu and neovim 0.8
<img width="1483" alt="image" src="https://user-images.githubusercontent.com/9933601/199344096-c49f926c-1a47-4543-b951-0ecbd2fea12c.png">

It seems that the queries were out of sync with [LhKipp/tree-sitter-nu](https://github.com/LhKipp/tree-sitter-nu). This update resolves the issue.