### PR TITLE
Fix indexing into nil value

### DIFF
--- a/lua/nu.lua
+++ b/lua/nu.lua
@@ -9,7 +9,7 @@ local function defaultConfig()
 end
 
 function M.setup(options)
-    M.options = v.tbl_extend("keep", options, defaultConfig())
+    M.options = v.tbl_extend("keep", options or {}, defaultConfig())
 end
 
 local is_initialised = false
@@ -19,7 +19,7 @@ function M._init()
     end
     is_initialised = true
 
-    if M.options.use_lsp_features then
+    if M.options and M.options.use_lsp_features then
         require 'nu.lsp'.init(M.options.all_cmd_names)
     end
 end


### PR DESCRIPTION
There are nil guards missing that are causing this error, whenever opening a Nu file:
```
Error detected while processing BufReadPost Autocommands for "*":
Error executing lua callback: ...brew/Cellar/neovim/0.8.3/share/nvim/runtime/filetype.lua:22: Error executing lua: ...brew/Cellar/neovim/0.8.3/share/nvim/runtime/filetype.lua:23: Vim(runtime):E5113: Error while c
alling lua chunk: /Users/celo/.local/share/nvim/plugged/nvim-nu/lua/nu.lua:22: attempt to index field 'options' (a nil value)
stack traceback:
        /Users/celo/.local/share/nvim/plugged/nvim-nu/lua/nu.lua:22: in function '_init'
        ...s/celo/.local/share/nvim/plugged/nvim-nu/ftplugin/nu.lua:1: in main chunk
        [C]: in function 'nvim_cmd'
        ...brew/Cellar/neovim/0.8.3/share/nvim/runtime/filetype.lua:23: in function <...brew/Cellar/neovim/0.8.3/share/nvim/runtime/filetype.lua:22>
        [C]: in function 'nvim_buf_call'
        ...brew/Cellar/neovim/0.8.3/share/nvim/runtime/filetype.lua:22: in function <...brew/Cellar/neovim/0.8.3/share/nvim/runtime/filetype.lua:11>
stack traceback:
        [C]: in function 'nvim_cmd'
        ...brew/Cellar/neovim/0.8.3/share/nvim/runtime/filetype.lua:23: in function <...brew/Cellar/neovim/0.8.3/share/nvim/runtime/filetype.lua:22>
        [C]: in function 'nvim_buf_call'
        ...brew/Cellar/neovim/0.8.3/share/nvim/runtime/filetype.lua:22: in function <...brew/Cellar/neovim/0.8.3/share/nvim/runtime/filetype.lua:11>
stack traceback:
        [C]: in function 'nvim_buf_call'
        ...brew/Cellar/neovim/0.8.3/share/nvim/runtime/filetype.lua:22: in function <...brew/Cellar/neovim/0.8.3/share/nvim/runtime/filetype.lua:11>
```

This PR adds guards before indexing into `options`. Also, a guard in the `tbl_extend` call, to catch nil `options` there.