### PR TITLE
fix(windows): no sh, assume nu installed instead

### DIFF
--- a/lua/nu/lsp.lua
+++ b/lua/nu/lsp.lua
@@ -14,7 +14,7 @@ local function cmd_names_from_cmd(cmd)
     log.debug("Running shell command", cmd)
 
     local proc = Job:new({
-        command = "sh",
+        command = "nu",
         args = { "-c", cmd },
         cwd = '.',
         enable_recording = true,


### PR DESCRIPTION
**Problem**: no sh under windows.

If you are using this plugin I guess it's safe to assume nu installed instead.

**NOTE**: I will admit I didn't test this extensively but at least when I open a nu file I don't get errors about sh executable missing.
