### PR TITLE
Don't override the tree-sitter grammar repository - let nvim-treesitter use the official one

### DIFF
--- a/plugin/nu.lua
+++ b/plugin/nu.lua
@@ -1,12 +1,5 @@
 local parser_config = require "nvim-treesitter.parsers".get_parser_configs()
-parser_config.nu = {
-    install_info = {
-        url = "https://github.com/LhKipp/tree-sitter-nu",
-        files = { "src/parser.c", "src/scanner.c" },
-        branch = "main"
-    },
-    filetype = "nu"
-}
+parser_config.nu.filetype = "nu"
 
 vim.filetype.add({
     extension = {


### PR DESCRIPTION
nvim-treesitter uses a lockfile with commit hashes of each grammar, and [the one for nu](https://github.com/nvim-treesitter/nvim-treesitter/blob/bb06afa3f1111780932b3c5493ad65473ce85f9d/lockfile.json#L503-L505) is https://github.com/nushell/tree-sitter-nu/commit/7e0f16f608a9e804fae61430ade734f9f849fb80 - a recent commit that does not appear in your fork (which was not updated in a year)