### PR TITLE
Manually set the revision for the tree-sitter grammar repository

### DIFF
--- a/plugin/nu.lua
+++ b/plugin/nu.lua
@@ -3,7 +3,8 @@ parser_config.nu = {
     install_info = {
         url = "https://github.com/LhKipp/tree-sitter-nu",
         files = { "src/parser.c", "src/scanner.c" },
-        branch = "main"
+        branch = "main",
+        revision = "ef943c6f2f7bfa061aad7db7bcaca63a002f354c",
     },
     filetype = "nu"
 }


### PR DESCRIPTION
Otherwise nvim-treesitter will use the revision from its lockfile, which uses a different repository with a different implementation of the grammar.