### PR TITLE
fix: delete deprecated `long_flag_equals_value` node type

### DIFF
--- a/queries/nu/highlights.scm
+++ b/queries/nu/highlights.scm
@@ -191,9 +191,7 @@ file_path: (val_string) @variable.parameter
 
 (param_long_flag ["--"] @punctuation.delimiter)
 (long_flag ["--"] @punctuation.delimiter)
-(long_flag_equals_value ["--"] @punctuation.delimiter)
 (short_flag ["-"] @punctuation.delimiter)
-(long_flag_equals_value ["="] @punctuation.special)
 (param_short_flag ["-"] @punctuation.delimiter)
 (param_rest "..." @punctuation.delimiter)
 (param_type [":"] @punctuation.special)


### PR DESCRIPTION
The node type was deleted in [tree-sitter-nu/pull/144](https://github.com/nushell/tree-sitter-nu/pull/144/files#diff-5ce2ef7cca8012910df446dce8eb09237b39a36ad64cc5535dc86cc4876d1dbfL192-L194)

This PR fixes the error:
```
Error in decoration provider treesitter/highlighter.win:                                                                                                                                                                                                                                                                  
Error executing lua: .../v0.10.2/share/nvim/runtime/lua/vim/treesitter/query.lua:252: Query error at 194:2. Invalid node type "long_flag_equals_value":                                                                                                                                                                   
(long_flag_equals_value ["--"] @punctuation.delimiter)                                                                                                                                                                                                                                                                    
 ^                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                          
stack traceback:                                                                                                                                                                                                                                                                                                          
        [C]: in function '_ts_parse_query'                                                                                                                                                                                                                                                                                
        .../v0.10.2/share/nvim/runtime/lua/vim/treesitter/query.lua:252: in function 'fn'                                                                                                                                                                                                                                 
        ...bob/v0.10.2/share/nvim/runtime/lua/vim/func/_memoize.lua:58: in function 'fn'                                                                                                                                                                                                                                  
        ...bob/v0.10.2/share/nvim/runtime/lua/vim/func/_memoize.lua:58: in function 'get'                                                                                                                                                                                                                                 
        ....2/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:28: in function 'new'                                                                                                                                                                                                                                 
        ....2/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:243: in function 'get_query'                                                                                                                                                                                                                          
        ....2/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:191: in function 'fn'                                                                                                                                                                                                                                 
        ...2/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:491: in function 'for_each_tree'                                                                                                                                                                                                                      
        ....2/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:178: in function 'prepare_highlight_states'    
```
Screenshot of the error:
![satty-20241210-11:50:35](https://github.com/user-attachments/assets/faa237cc-4729-4487-8a41-a04bc534ffc4)
